### PR TITLE
Hardcode email-based Cognito params in foundation workflow

### DIFF
--- a/.claude/commands/git-commit-message.md
+++ b/.claude/commands/git-commit-message.md
@@ -5,4 +5,4 @@ Run `git diff --cached` to see what is staged, and `git log --oneline -5` to see
 3. Keeps the subject line under 72 characters
 4. Adds a body only if the change needs explanation beyond the subject line
 
-Stage the commit but do NOT push.
+Output the commit message in chat for the user to run themselves. Do NOT run git commit.

--- a/.github/workflows/foundation.yml
+++ b/.github/workflows/foundation.yml
@@ -60,7 +60,10 @@ jobs:
               CustomDomain=${{ vars.CUSTOM_DOMAIN }} \
               AcmCertificateArn=${{ vars.ACM_CERTIFICATE_ARN }} \
               FrontendBucketName=${{ vars.FRONTEND_BUCKET_NAME }} \
-              CognitoDomainPrefix=${{ vars.COGNITO_DOMAIN_PREFIX }}
+              CognitoDomainPrefix=${{ vars.COGNITO_DOMAIN_PREFIX }} \
+              CognitoUsernameAttributes=email \
+              CognitoAutoVerifiedAttributes=email \
+              CognitoAdminCreateUserOnly=true
 
       - name: Show stack outputs
         run: |


### PR DESCRIPTION
All environments use email login — hardcoding prevents accidental revert to phone/username defaults if the workflow is re-run without explicit overrides.