### PR TITLE
Improve CD visibility and skip noisy Checkov checks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,7 @@
 # Main promotes from the last successful qa CD run (the artifact qa was actually deployed with).
 # Each environment uses its own AWS role and stack.
 name: CD
+run-name: "CD — ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
 
 on:
   workflow_run:

--- a/.github/workflows/foundation.yml
+++ b/.github/workflows/foundation.yml
@@ -46,6 +46,12 @@ jobs:
           file: infra/foundation.yaml
           framework: cloudformation
           soft_fail: true
+          # CKV_AWS_111: sns:Publish * is required for Cognito SMS (ARN is dynamic)
+          # CKV_AWS_21:  S3 versioning adds cost with no value for a static site bucket
+          # CKV_AWS_18:  S3 access logging requires a second bucket — overkill here
+          # CKV_AWS_68:  CloudFront WAF costs per-request — not appropriate for this project
+          # CKV_AWS_86:  CloudFront logging requires a second bucket — overkill here
+          skip_check: CKV_AWS_111,CKV_AWS_21,CKV_AWS_18,CKV_AWS_68,CKV_AWS_86
 
       - name: Deploy foundation stack
         run: |


### PR DESCRIPTION
CD run-name now shows the target environment so dev deploys are identifiable in the Actions UI alongside qa and main. Skip Checkov checks that add cost or don't apply to a static-site hosting setup.