### PR TITLE
fix: wire local dev to correct Cognito pool and fix SAM local on Appl…

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,16 @@
   "permissions": {
     "allow": [
       "Bash(gh api:*)",
-      "Bash(aws iam:*)"
+      "Bash(aws iam:*)",
+      "Bash(docker run:*)",
+      "Bash(rm -rf /Users/dallaslacomb/Documents/DalTime/backend/.aws-sam)",
+      "Bash(sam build:*)",
+      "Bash(echo \"exit: $?\")",
+      "Bash(timeout 20 sam local start-api --port 3000 --env-vars local/env.json --warm-containers EAGER --parameter-overrides LambdaArchitecture=arm64)",
+      "Bash(echo \"mount exit: $?\")"
+    ],
+    "additionalDirectories": [
+      "/tmp"
     ]
   }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Backend: Build SAM",
       "type": "shell",
-      "command": "sam build",
+      "command": "sam build --build-dir /tmp/daltime-sam-build --parameter-overrides LambdaArchitecture=arm64",
       "options": {
         "cwd": "${workspaceFolder}/backend"
       },
@@ -22,7 +22,7 @@
     {
       "label": "Backend: Start Local API",
       "type": "shell",
-      "command": "sam local start-api --port 3000 --env-vars local/env.json --warm-containers EAGER --parameter-overrides LambdaArchitecture=x86_64",
+      "command": "sam build --build-dir /tmp/daltime-sam-build --parameter-overrides LambdaArchitecture=arm64 && sam local start-api --port 3000 --env-vars local/env.json --warm-containers EAGER --parameter-overrides LambdaArchitecture=arm64 --template-file /tmp/daltime-sam-build/template.yaml",
       "options": {
         "cwd": "${workspaceFolder}/backend"
       },
@@ -45,7 +45,7 @@
         "panel": "dedicated",
         "clear": false
       },
-      "dependsOn": ["Backend: Build SAM", "DynamoDB Local: Create Tables"]
+      "dependsOn": ["DynamoDB Local: Create Tables"]
     },
     {
       "label": "Backend: Invoke Test Function",

--- a/frontend/src/app/core/auth/auth.ts
+++ b/frontend/src/app/core/auth/auth.ts
@@ -72,7 +72,7 @@ export class AuthService {
         this.accessToken = loginResponse.accessToken;
         this.idToken = loginResponse.idToken;
 
-        const role = this.extractUserRole(loginResponse.userData);
+        const role = this.extractUserRole(loginResponse.accessToken);
         this._role$.next(role);
 
         this.getUserAttributes();
@@ -128,14 +128,23 @@ export class AuthService {
   }
 
   /**
-   * Extracts UserRole from the OIDC userData claims.
-   * Checks custom:user_type first (Cognito's custom attribute prefix), falls back to user_type.
+   * Extracts UserRole from the Cognito access token's cognito:groups claim.
+   * Groups are only present in the access token, not the ID token/userData.
+   * The first matching group (by precedence order in VALID_ROLES) is used.
    */
-  private extractUserRole(userData: Record<string, unknown> | null): UserRole | null {
-    if (!userData) return null;
-    const raw = userData['custom:user_type'] ?? userData['user_type'];
-    if (isValidRole(raw)) return raw;
-    console.warn('No valid user_type claim found in token. Got:', raw);
+  private extractUserRole(accessToken: string | null): UserRole | null {
+    if (!accessToken) return null;
+
+    try {
+      const payload = JSON.parse(atob(accessToken.split('.')[1]));
+      const groups: unknown[] = payload['cognito:groups'] ?? [];
+      const role = groups.find((g) => isValidRole(g)) as UserRole | undefined;
+      if (role) return role;
+    } catch {
+      // malformed token — fall through to warning
+    }
+
+    console.warn('No valid Cognito group found in access token.');
     return null;
   }
 

--- a/frontend/src/app/features/employee/employee-dashboard/employee-dashboard.html
+++ b/frontend/src/app/features/employee/employee-dashboard/employee-dashboard.html
@@ -10,8 +10,7 @@
       <dd>{{ user().email }}</dd>
       <dt>Name</dt>
       <dd>{{ user().name || user().given_name + ' ' + user().family_name }}</dd>
-      <dt>User Type</dt>
-      <dd>{{ user()['custom:user_type'] }}</dd>
+
       <dt>Org ID</dt>
       <dd>{{ user()['custom:org_id'] || 'N/A' }}</dd>
       <dt>Sub</dt>

--- a/frontend/src/app/features/manager/manager-dashboard/manager-dashboard.html
+++ b/frontend/src/app/features/manager/manager-dashboard/manager-dashboard.html
@@ -10,8 +10,7 @@
       <dd>{{ user().email }}</dd>
       <dt>Name</dt>
       <dd>{{ user().name || user().given_name + ' ' + user().family_name }}</dd>
-      <dt>User Type</dt>
-      <dd>{{ user()['custom:user_type'] }}</dd>
+
       <dt>Org ID</dt>
       <dd>{{ user()['custom:org_id'] || 'N/A' }}</dd>
       <dt>Sub</dt>

--- a/frontend/src/app/features/org-admin/org-admin-dashboard/org-admin-dashboard.html
+++ b/frontend/src/app/features/org-admin/org-admin-dashboard/org-admin-dashboard.html
@@ -10,8 +10,7 @@
       <dd>{{ user().email }}</dd>
       <dt>Name</dt>
       <dd>{{ user().name || user().given_name + ' ' + user().family_name }}</dd>
-      <dt>User Type</dt>
-      <dd>{{ user()['custom:user_type'] }}</dd>
+
       <dt>Org ID</dt>
       <dd>{{ user()['custom:org_id'] || 'N/A' }}</dd>
       <dt>Sub</dt>

--- a/frontend/src/app/features/web-admin/web-admin-dashboard/web-admin-dashboard.html
+++ b/frontend/src/app/features/web-admin/web-admin-dashboard/web-admin-dashboard.html
@@ -10,8 +10,7 @@
       <dd>{{ user().email }}</dd>
       <dt>Name</dt>
       <dd>{{ user().name || user().given_name + ' ' + user().family_name }}</dd>
-      <dt>User Type</dt>
-      <dd>{{ user()['custom:user_type'] }}</dd>
+
       <dt>Org ID</dt>
       <dd>{{ user()['custom:org_id'] || 'N/A' }}</dd>
       <dt>Sub</dt>

--- a/frontend/src/environments/environment.dev.ts
+++ b/frontend/src/environments/environment.dev.ts
@@ -3,10 +3,10 @@ export const environment = {
   name: 'dev',
   production: false,
   cognito: {
-    userPoolId: 'us-east-1_LVp3uUQ5l',
-    clientId: '1vvrr1dvepebrkl1v246pbijju',
+    userPoolId: 'us-east-1_kzQ806uSv',
+    clientId: '1nl13tbaqb47s8f0tfc07lc24m',
     region: 'us-east-1',
-    domain: 'https://us-east-1lvp3uuq5l.auth.us-east-1.amazoncognito.com',
+    domain: 'daltime-dev.auth.us-east-1.amazoncognito.com',
   },
   api: {
     baseUrl: 'https://ddy3hzd0ef.execute-api.us-east-1.amazonaws.com',

--- a/frontend/src/environments/environment.local.ts
+++ b/frontend/src/environments/environment.local.ts
@@ -3,10 +3,10 @@ export const environment = {
   name: 'local',
   production: false,
   cognito: {
-    userPoolId: 'us-east-1_LVp3uUQ5l',
-    clientId: '1vvrr1dvepebrkl1v246pbijju',
+    userPoolId: 'us-east-1_kzQ806uSv',
+    clientId: '1nl13tbaqb47s8f0tfc07lc24m',
     region: 'us-east-1',
-    domain: 'https://us-east-1lvp3uuq5l.auth.us-east-1.amazoncognito.com',
+    domain: 'daltime-dev.auth.us-east-1.amazoncognito.com',
   },
   api: {
     baseUrl: 'http://localhost:3000',


### PR DESCRIPTION
…e Silicon

Point dev/local environments at the real daltime-dev Cognito pool (us-east-1_kzQ806uSv) which was never provisioned under the old IDs. Add localhost:4200 as an allowed callback/logout URL on the app client.

Switch role extraction to read cognito:groups from the access token instead of custom:user_type from userData, matching how Cognito actually surfaces group membership.

Work around a Docker Desktop VirtioFS bug that prevents the Lambda rapid image from bind-mounting subdirectories under .aws-sam/build by building to /tmp instead.